### PR TITLE
Add HSTS to Hapi example in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ server.connection({
     ciphers: sslConfig.ciphers,
     honorCipherOrder: true,
     secureOptions: sslConfig.minimumTLSVersion
+  },
+  routes: {
+    security: true // turns on HSTS and other security headers
   }
 });
 ```


### PR DESCRIPTION
Hapi has the ability to include HSTS headers and a few other security headers, so might as well mention that in the README example. :-D
